### PR TITLE
Enable dark theme support

### DIFF
--- a/src/crxviewer.js
+++ b/src/crxviewer.js
@@ -23,6 +23,22 @@
 
 'use strict';
 
+(function applyTheme() {
+    var storageArea = chrome && chrome.storage && chrome.storage.sync;
+    function setTheme(pref) {
+        var useDark = typeof pref === 'boolean' ? pref :
+            window.matchMedia('(prefers-color-scheme: dark)').matches;
+        document.documentElement.classList.toggle('dark-theme', useDark);
+    }
+    if (storageArea) {
+        storageArea.get('useDarkTheme', function(items) {
+            setTheme(items && items.useDarkTheme);
+        });
+    } else {
+        setTheme();
+    }
+})();
+
 // crx_url is globally set to the URL of the shown file for ease of debugging.
 // If there is no URL (e.g. with  <input type=file>), then crx_url is the file name.
 

--- a/src/crxviewer.less
+++ b/src/crxviewer.less
@@ -409,3 +409,53 @@ img:hover {
 }
 
 @import (less) "search-tools.less";
+
+.dark-theme-styles() {
+    body {
+        background: #202124;
+        color: #eee;
+    }
+    #left-panel {
+        background-color: #2b2b2b;
+        > .resizer {
+            background-color: #444;
+            &:hover {
+                background-color: #666;
+            }
+        }
+    }
+    #file-list {
+        li:hover {
+            background-color: rgba(255, 255, 255, 0.1);
+        }
+        li.active {
+            background-color: rgba(255, 255, 255, 0.2);
+        }
+        li.file-selected {
+            background-color: #264f78;
+        }
+        .file-dir {
+            color: #ccc;
+        }
+    }
+    footer {
+        border-top-color: #559;
+    }
+    .content-verifier-output {
+        background: #202124;
+        border-color: #559;
+    }
+    .search-result-highlight,
+    .file-specific-toolbar .find-all-enabled {
+        outline: 1px solid orange;
+        background: rgba(255, 255, 100, 0.15);
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    .dark-theme-styles();
+}
+
+html.dark-theme {
+    .dark-theme-styles();
+}

--- a/src/lib/prettify/prettify.css
+++ b/src/lib/prettify/prettify.css
@@ -74,3 +74,51 @@
 li:hover {
     background: #EEE;
 }
+
+@media (prefers-color-scheme: dark) {
+  .token.comment,
+  .token.prolog,
+  .token.doctype,
+  .token.cdata {
+    color: #9ca0a6;
+  }
+  .token.punctuation,
+  .token.string,
+  .token.atrule,
+  .token.attr-value {
+    color: #8ab4f8;
+  }
+  .token.property,
+  .token.tag {
+    color: #57b366;
+  }
+  .odd-code-line {
+    background: #2b2b2b;
+  }
+  li:hover {
+    background: #333;
+  }
+}
+
+html.dark-theme .token.comment,
+html.dark-theme .token.prolog,
+html.dark-theme .token.doctype,
+html.dark-theme .token.cdata {
+  color: #9ca0a6;
+}
+html.dark-theme .token.punctuation,
+html.dark-theme .token.string,
+html.dark-theme .token.atrule,
+html.dark-theme .token.attr-value {
+  color: #8ab4f8;
+}
+html.dark-theme .token.property,
+html.dark-theme .token.tag {
+  color: #57b366;
+}
+html.dark-theme .odd-code-line {
+  background: #2b2b2b;
+}
+html.dark-theme li:hover {
+  background: #333;
+}

--- a/src/options.html
+++ b/src/options.html
@@ -55,6 +55,10 @@ footer {
 </label>
 <!--#endif-->
 <label>
+    <input type="checkbox" id="darktheme">
+    Use dark theme
+</label>
+<label>
     <a href="crxviewer.html">Open Viewer</a> - select a CRX / NEX / XPI / ZIP file to view its contents.
 </label>
 <footer>

--- a/src/options.js
+++ b/src/options.js
@@ -10,9 +10,13 @@
 
 var storageArea = chrome.storage.sync;
 var contextmenuPatternsInput = document.getElementById('contextmenuPatterns');
+var darkThemeCheckbox = document.getElementById('darktheme');
 document.getElementById('contextmenu').onchange = function() {
     storageArea.set({showContextMenu: this.checked});
     contextmenuPatternsInput.disabled = !this.checked;
+};
+darkThemeCheckbox.onchange = function() {
+    storageArea.set({useDarkTheme: this.checked});
 };
 
 contextmenuPatternsInput.oninput = function() {
@@ -56,6 +60,7 @@ storageArea.get({
 //#if FIREFOX
     showPageAction: true,
 //#endif
+    useDarkTheme: null,
 }, function(items) {
     document.getElementById('contextmenu').checked = items.showContextMenu;
     contextmenuPatternsInput.disabled = !items.showContextMenu;
@@ -63,6 +68,7 @@ storageArea.get({
 //#if FIREFOX
     document.getElementById('pageaction').checked = items.showPageAction;
 //#endif
+    darkThemeCheckbox.checked = items.useDarkTheme === true;
 });
 
 //#if FIREFOX

--- a/src/popup.html
+++ b/src/popup.html
@@ -29,6 +29,12 @@
     #download:not(.downloading) .busy {
         display: none;
     }
+    @media (prefers-color-scheme: dark) {
+        body {background:#202124;color:#eee;}
+        button {background:#333;color:#eee;}
+    }
+    .dark-theme body {background:#202124;color:#eee;}
+    .dark-theme button {background:#333;color:#eee;}
 </style>
 </head>
 <body>
@@ -48,5 +54,20 @@
 <script src="chrome-platform-info.js"></script>
 <script src="cws_pattern.js"></script>
 <script src="popup.js"></script>
+<script>
+  (function(){
+    var storage = chrome && chrome.storage && chrome.storage.sync;
+    function apply(pref){
+      var useDark = typeof pref === 'boolean' ? pref :
+        window.matchMedia('(prefers-color-scheme: dark)').matches;
+      document.documentElement.classList.toggle('dark-theme', useDark);
+    }
+    if(storage){
+      storage.get('useDarkTheme', function(it){apply(it && it.useDarkTheme);});
+    }else{
+      apply();
+    }
+  })();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add dark theme styles for viewer and code blocks
- support dark theme toggle on options page and popup
- apply the theme based on the stored setting or system preference
- recompile `crxviewer.less`

## Testing
- `node make.js web`

------
https://chatgpt.com/codex/tasks/task_e_68418a8c95b08325a02db825e001aa52